### PR TITLE
Refactor number formatting

### DIFF
--- a/src/utils/pricing.js
+++ b/src/utils/pricing.js
@@ -2,28 +2,22 @@ export function formatNumber(num) {
 	if (num === undefined || num === null || typeof num !== 'number' || isNaN(num)) {
 		return '0'
 	}
-	if (num < 1000) {
-		return num.toString()
-	}
-	if (num < 1000000) {
-		const thousands = num / 1000
-		if (thousands === Math.floor(thousands)) {
-			return thousands + 'k'
+
+	const units = [
+		{ value: 1000000000, suffix: 'B' },
+		{ value: 1000000, suffix: 'M' },
+		{ value: 1000, suffix: 'k' }
+	]
+
+	for (const { value, suffix } of units) {
+		if (num >= value) {
+			const scaled = num / value
+			const rounded = scaled === Math.floor(scaled) ? scaled : Math.round(scaled * 10) / 10
+			return rounded + suffix
 		}
-		return Math.round(thousands * 10) / 10 + 'k'
 	}
-	if (num < 1000000000) {
-		const millions = num / 1000000
-		if (millions === Math.floor(millions)) {
-			return millions + 'M'
-		}
-		return Math.round(millions * 10) / 10 + 'M'
-	}
-	const billions = num / 1000000000
-	if (billions === Math.floor(billions)) {
-		return billions + 'B'
-	}
-	return Math.round(billions * 10) / 10 + 'B'
+
+	return num.toString()
 }
 
 export function formatCurrency(num, roundToWhole = false) {


### PR DESCRIPTION
## Summary
- refactor `formatNumber` to use a small lookup table

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685fd85677f88327aeac08da78cb3ffe