### PR TITLE
Enforce 300-item cap in Add Shop Item modal

### DIFF
--- a/src/components/ShopItemForm.vue
+++ b/src/components/ShopItemForm.vue
@@ -44,6 +44,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['submit', 'cancel'])
+const SHOP_ITEM_LIMIT = 300
 
 // Form data
 const formData = ref({
@@ -173,6 +174,28 @@ const showAlreadyInShopNotice = computed(() => {
 		return selectedItemIds.value.some((id) => ids.includes(id))
 	}
 	return !!formData.value.item_id && ids.includes(formData.value.item_id)
+})
+
+const projectedShopItemCount = computed(() => {
+	if (props.editingItem) return 0
+
+	const existingIds = new Set(props.existingItemIds || [])
+
+	if (enableMultipleSelection.value) {
+		const newSelections = selectedItemIds.value.filter((id) => !existingIds.has(id))
+		return existingIds.size + newSelections.length
+	}
+
+	if (!formData.value.item_id || existingIds.has(formData.value.item_id)) {
+		return existingIds.size
+	}
+
+	return existingIds.size + 1
+})
+
+const hasShopItemLimitError = computed(() => {
+	if (props.editingItem) return false
+	return projectedShopItemCount.value > SHOP_ITEM_LIMIT
 })
 
 // Get all enchantment items
@@ -392,6 +415,10 @@ const isFormValid = computed(() => {
 		return false
 	}
 
+	if (hasShopItemLimitError.value) {
+		return false
+	}
+
 	return true
 })
 
@@ -490,6 +517,11 @@ function handleSubmit() {
 			}
 		}
 
+		if (hasShopItemLimitError.value) {
+			formError.value = 'item_limit'
+			return
+		}
+
 		// Create array of items with shared form data
 		const baseData = {
 			buy_price: formData.value.buy_price ?? null,
@@ -542,6 +574,11 @@ function handleSubmit() {
 				formError.value = 'sell_price'
 				return
 			}
+		}
+
+		if (hasShopItemLimitError.value) {
+			formError.value = 'item_limit'
+			return
 		}
 
 		// Clean up form data before submitting
@@ -1016,7 +1053,8 @@ defineExpose({
 	focusSearchInput,
 	submit: handleSubmit,
 	isFormValid,
-	selectedItemsCount: computed(() => selectedItemIds.value.length)
+	selectedItemsCount: computed(() => selectedItemIds.value.length),
+	hasShopItemLimitError
 })
 </script>
 
@@ -1120,6 +1158,13 @@ defineExpose({
 							title="Already in shop"
 							message="One or more of these items have already been added to this shop"
 							class="mt-2" />
+						<NotificationBanner
+							v-if="hasShopItemLimitError"
+							type="error"
+							size="compact"
+							title="Shop item limit reached"
+							:message="`A shop can have up to ${SHOP_ITEM_LIMIT} items. Your current selection would bring this shop to ${projectedShopItemCount} items.`"
+							class="mt-2" />
 					</div>
 
 					<!-- Item selection dropdown -->
@@ -1213,6 +1258,13 @@ defineExpose({
 						size="compact"
 						title="Already in shop"
 						message="This item has already been added to this shop"
+						class="mt-2" />
+					<NotificationBanner
+						v-if="hasShopItemLimitError"
+						type="error"
+						size="compact"
+						title="Shop item limit reached"
+						:message="`A shop can have up to ${SHOP_ITEM_LIMIT} items. Your current selection would bring this shop to ${projectedShopItemCount} items.`"
 						class="mt-2" />
 				</div>
 			</div>

--- a/src/views/ShopItemsView.vue
+++ b/src/views/ShopItemsView.vue
@@ -1844,7 +1844,9 @@ function getServerName(serverId) {
 						type="button"
 						variant="primary"
 						data-cy="shop-item-form-submit-button"
-						:disabled="loading || !shopItemForm?.isFormValid"
+						:disabled="
+							loading || !shopItemForm?.isFormValid || shopItemForm?.hasShopItemLimitError
+						"
 						@click="shopItemForm?.submit()">
 						{{
 							loading


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a 300-item shop limit guard to `ShopItemForm` by calculating projected item count from existing shop items plus newly selected unique items
- show a compact error banner in the same selection-notice area as the existing "already in shop" message when the projected total exceeds 300
- expose limit-error state from `ShopItemForm` and disable the modal footer submit button while the limit error is active

## Validation
- `npm run build` ✅
- `npm run lint` ⚠️ fails due to many pre-existing lint violations across the repo (unrelated to this change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b8d9010-8f5e-45cc-ba79-a6fd21e39239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b8d9010-8f5e-45cc-ba79-a6fd21e39239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

